### PR TITLE
#1_Eliminación_node_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+sharex-backend/node_modules/
+sharex-frontend/node_modules/

--- a/sharex-backend/node_modules/.package-lock.json
+++ b/sharex-backend/node_modules/.package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "google-drive-casero",
+  "name": "sharex",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
@@ -407,10 +407,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/google-drive-casero": {
-      "resolved": "",
-      "link": true
     },
     "node_modules/gopd": {
       "version": "1.2.0",
@@ -832,6 +828,10 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
+    },
+    "node_modules/sharex": {
+      "resolved": "",
+      "link": true
     },
     "node_modules/side-channel": {
       "version": "1.1.0",

--- a/sharex-backend/package-lock.json
+++ b/sharex-backend/package-lock.json
@@ -1,18 +1,18 @@
 {
-  "name": "google-drive-casero",
+  "name": "sharex",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "google-drive-casero",
+      "name": "sharex",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
         "cors": "^2.8.5",
         "express": "^4.21.2",
-        "google-drive-casero": "file:",
-        "multer": "^1.4.5-lts.1"
+        "multer": "^1.4.5-lts.1",
+        "sharex": "file:"
       }
     },
     "node_modules/accepts": {
@@ -418,10 +418,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/google-drive-casero": {
-      "resolved": "",
-      "link": true
     },
     "node_modules/gopd": {
       "version": "1.2.0",
@@ -843,6 +839,10 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
+    },
+    "node_modules/sharex": {
+      "resolved": "",
+      "link": true
     },
     "node_modules/side-channel": {
       "version": "1.1.0",

--- a/sharex-backend/package.json
+++ b/sharex-backend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "google-drive-casero",
+  "name": "sharex",
   "version": "1.0.0",
   "main": "server.js",
   "scripts": {
@@ -13,7 +13,7 @@
   "dependencies": {
     "cors": "^2.8.5",
     "express": "^4.21.2",
-    "google-drive-casero": "file:",
-    "multer": "^1.4.5-lts.1"
+    "multer": "^1.4.5-lts.1",
+    "sharex": "file:"
   }
 }


### PR DESCRIPTION
Se ha creado el archivo gitignore para poder ignorar los archivos node_modules tanto del back como del front